### PR TITLE
Undefined method `configure' for MoneyRails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'font-awesome-sass'
 gem 'simple_form'
 gem 'autoprefixer-rails'
 
-gem 'money-rails'
+gem 'money-rails', '~>1'
 
 gem 'wx_pay'
 gem 'rqrcode'


### PR DESCRIPTION
When trying to follow along with the teacher's demo for the stripe tutorial, I was getting a "undefined method `configure' for MoneyRails" error in my terminal until I specified the MoneyRails version.